### PR TITLE
✨ Add Type Check Equals operator

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -95,17 +95,17 @@ impl Interpreter {
                 
                 }
             }
-            // Expr::Equals(left, right) => {
-            //     let left = self.eval_expr(*left);
-            //     let right = self.eval_expr(*right);
+            Expr::TypeCheckEquals(left, right) => {
+                let left = self.eval_expr(*left);
+                let right = self.eval_expr(*right);
 
-            //     match (left, right) {
-            //         (Value::Float(left), Value::Float(right)) => Value::Boolean(left == right),
-            //         (Value::StringLiteral(left), Value::StringLiteral(right)) => Value::Boolean(left == right),
-            //         (Value::Boolean(left), Value::Boolean(right)) => Value::Boolean(left == right),
-            //         _ => Value::Boolean(false),
-            //     }
-            // }
+                match (left, right) {
+                    (Value::Float(left), Value::Float(right)) => Value::Boolean(left == right),
+                    (Value::StringLiteral(left), Value::StringLiteral(right)) => Value::Boolean(left == right),
+                    (Value::Boolean(left), Value::Boolean(right)) => Value::Boolean(left == right),
+                    _ => Value::Boolean(false),
+                }
+            }
             Expr::Addition(left, right) => {
                 let left = self.eval_expr(*left);
                 let right = self.eval_expr(*right);

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -40,8 +40,18 @@ impl<'a> Lexer<'a> {
 
                     match char {
                         '=' => {
-                            self.pos += 2;
-                            return Some(Token::Equals);
+                            let char = self.code.chars().nth(self.pos + 2)?;
+
+                            match char {
+                                '=' => {
+                                    self.pos += 3;
+                                    return Some(Token::TypeCheckEquals);
+                                },
+                                _ => {
+                                    self.pos += 2;
+                                    return Some(Token::Equals);
+                                }
+                            }
                         },
                         _ => {
                             self.pos += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ fn main() {
         log(y * x);
         y = 10;
         let isWorking = 'true' == false;
-        log(isWorking);
+        log(true == 1);
+        log(true === 1)
         // {
         //     let x = 5;
         //     log(x);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -66,6 +66,12 @@ impl Parser {
 
                     return Expr::Equals(Box::new(left), Box::new(right));
                 }
+                Some(Token::TypeCheckEquals) => {
+                    let left = expr.pop().expect("Expected left side of equals");
+                    let right = self.parse_expr();
+
+                    return Expr::TypeCheckEquals(Box::new(left), Box::new(right));
+                }
                 Some(Token::Addition) => {
                     let left = expr.pop().expect("Expected left side of addition");
                     let right = self.parse_expr();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,21 +1,22 @@
 #[derive(Debug, PartialEq, Clone)]
 pub enum Token {
-    Let,
     Identifier(String),
-    Equals,
     Float(f64),
     StringLiteral(String),
-    Semicolon,
-    Log,
-    ParenClose,
-    ParenOpen,
-    Comment(String),
+    Equals,
+    TypeCheckEquals,
+    Assign,
     Addition,
     Subtraction,
     Multiplication,
     Division,
     Boolean(bool),
-    Assign,
+    Semicolon,
+    ParenClose,
+    ParenOpen,
+    Comment(String),
+    Log,
+    Let,
 }
 
 #[derive(Debug, PartialEq)]
@@ -29,6 +30,7 @@ pub enum Expr {
     Multiplication(Box<Expr>, Box<Expr>),
     Division(Box<Expr>, Box<Expr>),
     Equals(Box<Expr>, Box<Expr>),
+    TypeCheckEquals(Box<Expr>, Box<Expr>),
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Added a new operator for type-checking equality between expressions to
handle comparisons based on both value and type. Updated lexer, parser,
interpreter, and types accordingly.