### PR TITLE
✨ Add 'If' statement evaluation to Interpreter

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,6 +28,7 @@ impl Interpreter {
                 Stmt::Log(expr) => self.eval_log(expr),
                 Stmt::Assignment(name, value) => self.eval_let(name, value),
                 Stmt::Comment(_) => (),
+                Stmt::If(condition, stmts) => self.eval_if(condition, stmts),
             }
         }
     }
@@ -40,6 +41,19 @@ impl Interpreter {
     fn eval_log(&mut self, expr: Expr) {
         let value = self.eval_expr(expr);
         println!("{:?}", value);
+    }
+
+    fn eval_if(&mut self, condition: Box<Expr>, stmts: Vec<Stmt>) {
+        let result = self.eval_expr(*condition);
+
+        match result {
+            Value::Boolean(true) => {
+                self.eval(stmts);
+                Value::Boolean(true)
+            },
+            Value::Boolean(false) => Value::Boolean(false),
+            _ => panic!("Expected a boolean expression"),
+        };
     }
 
     fn eval_expr(&mut self, expr: Expr) -> Value {
@@ -141,7 +155,8 @@ impl Interpreter {
                     (Value::Float(left), Value::Float(right)) => Value::Float(left / right),
                     _ => panic!("Expected two numbers"),
                 }
-            },
+            }
+            _ => panic!("Expected an expression"),
         }
     }
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -75,6 +75,14 @@ impl<'a> Lexer<'a> {
                     self.pos += 1;
                     return Some(Token::Semicolon);
                 }
+                '{' => {
+                    self.pos += 1;
+                    return Some(Token::BraceOpen);
+                }
+                '}' => {
+                    self.pos += 1;
+                    return Some(Token::BraceClose);
+                }
                 '(' => {
                     self.pos += 1;
                     return Some(Token::ParenOpen);
@@ -123,6 +131,9 @@ impl<'a> Lexer<'a> {
             "log" => Some(Token::Log),
             "true" => Some(Token::Boolean(true)),
             "false" => Some(Token::Boolean(false)),
+            "if" => Some(Token::If),
+            "else" => Some(Token::Else),
+            "elseif" => Some(Token::ElseIf),
             _ => Some(Token::Identifier(ident.to_string())),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,16 +10,26 @@ use lexer::Lexer;
 fn main() {
     let code = r#"
         let x = 3;
-        let y = x + 3 + 3;
-        let m = 'Manoj';
-        log(x + 1);
-        log(m);
-        log(y - x);
-        log(y * x);
-        y = 10;
-        let isWorking = 'true' == false;
-        log(true == 1);
-        log(true === 1)
+        // let y = x + 3 + 3;
+        // let m = 'Manoj';
+        // log(x + 1);
+        // log(m);
+        // log(y - x);
+        // log(y * x);
+        // y = 10;
+        // let isWorking = 'true' == false;
+        // log(true == 1);
+        // log(true === 1)
+
+        log(x == 3);
+
+        if (x == 4) {
+            log('x is 3');
+        }
+        // } else {
+        //     log('x is not 3');
+        // }
+
         // {
         //     let x = 5;
         //     log(x);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,9 +12,14 @@ pub enum Token {
     Division,
     Boolean(bool),
     Semicolon,
-    ParenClose,
+    BraceOpen,
+    BraceClose,
     ParenOpen,
+    ParenClose,
     Comment(String),
+    If,
+    Else,
+    ElseIf,
     Log,
     Let,
 }
@@ -31,12 +36,14 @@ pub enum Expr {
     Division(Box<Expr>, Box<Expr>),
     Equals(Box<Expr>, Box<Expr>),
     TypeCheckEquals(Box<Expr>, Box<Expr>),
+    If(Box<Expr>, Vec<Stmt>),
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Stmt {
     Let(String, Expr),
     Assignment(String, Expr),
+    If(Box<Expr>, Vec<Stmt>),
     Log(Expr),
     Comment(String),
 }


### PR DESCRIPTION
A new method `eval_if` has been added to the Interpreter to handle
the evaluation of 'If' statements. If the condition is true, the
statements will be executed. Otherwise, it will return false.