### PR TITLE
✨ Add ne and type ne expr operators

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -120,6 +120,64 @@ impl Interpreter {
                     _ => Value::Boolean(false),
                 }
             }
+            Expr::NotEquals(left, right) => {
+                let left = self.eval_expr(*left);
+                let right = self.eval_expr(*right);
+
+                match (left) {
+                    Value::Float(left) => {
+                        let corced_right = match (right) {
+                            Value::Float(right) => Some(right),
+                            Value::StringLiteral(right) => right.parse::<f64>().ok(),
+                            Value::Boolean(right) => Some(right as i32 as f64),
+                            _ => Some(0.0),
+                        };
+
+                        match (corced_right) {
+                            Some(right) => Value::Boolean(left != right),
+                            None => Value::Boolean(false),
+                        }
+                    },
+                    Value::StringLiteral(left) => {
+                        let corced_right = match (right) {
+                            Value::Float(right) => Some(right.to_string()),
+                            Value::StringLiteral(right) => Some(right),
+                            Value::Boolean(right) => Some(right.to_string()),
+                        };
+
+                        Value::Boolean(left != corced_right.unwrap())
+                    }
+                    Value::Boolean(left) => {
+                        let corced_right = match (right) {
+                            Value::Float(right) => Some(right as i32 == 0),
+                            Value::StringLiteral(right) => {
+                                let value = right.parse::<i32>().ok();
+
+                                match value {
+                                    Some(value) => Some(value == 0),
+                                    None => Some(false),
+                                }
+                            }
+                            Value::Boolean(right) => Some(right),
+                        };
+
+                        Value::Boolean(left != corced_right.unwrap())
+                    },
+                    _ => panic!("Expected two expressions to compare"),
+                
+                }
+            }
+            Expr::TypeNotEquals(left, right) => {
+                let left = self.eval_expr(*left);
+                let right = self.eval_expr(*right);
+
+                match (left, right) {
+                    (Value::Float(left), Value::Float(right)) => Value::Boolean(left != right),
+                    (Value::StringLiteral(left), Value::StringLiteral(right)) => Value::Boolean(left != right),
+                    (Value::Boolean(left), Value::Boolean(right)) => Value::Boolean(left != right),
+                    _ => Value::Boolean(false),
+                }
+            }
             Expr::Addition(left, right) => {
                 let left = self.eval_expr(*left);
                 let right = self.eval_expr(*right);

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -35,6 +35,30 @@ impl<'a> Lexer<'a> {
                     let token = self.read_string_literal();
                     return token;
                 }
+                '!' => {
+                    let char = self.code.chars().nth(self.pos + 1)?;
+
+                    match char {
+                        '=' => {
+                            let char = self.code.chars().nth(self.pos + 2)?;
+
+                            match char {
+                                '=' => {
+                                    self.pos += 3;
+                                    return Some(Token::TypeNotEquals);
+                                },
+                                _ => {
+                                    self.pos += 2;
+                                    return Some(Token::NotEquals);
+                                }
+                            }
+                        },
+                        _ => {
+                            self.pos += 1;
+                            return Some(Token::Not);
+                        }
+                    }
+                }
                 '=' => {
                     let char = self.code.chars().nth(self.pos + 1)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
         // log(true == 1);
         // log(true === 1)
 
-        log(x == 3);
+        log(x != 2);
 
         if (x == 4) {
             log('x is 3');

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -74,6 +74,18 @@ impl Parser {
 
                     return Expr::TypeCheckEquals(Box::new(left), Box::new(right));
                 }
+                Some(Token::NotEquals) => {
+                    let left = expr.pop().expect("Expected left side of not equals");
+                    let right = self.parse_expr();
+
+                    return Expr::NotEquals(Box::new(left), Box::new(right));
+                }
+                Some(Token::TypeNotEquals) => {
+                    let left = expr.pop().expect("Expected left side of not equals");
+                    let right = self.parse_expr();
+
+                    return Expr::TypeNotEquals(Box::new(left), Box::new(right));
+                }
                 Some(Token::Addition) => {
                     let left = expr.pop().expect("Expected left side of addition");
                     let right = self.parse_expr();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,8 +3,11 @@ pub enum Token {
     Identifier(String),
     Float(f64),
     StringLiteral(String),
+    Not,
     Equals,
     TypeCheckEquals,
+    NotEquals,
+    TypeNotEquals,
     Assign,
     Addition,
     Subtraction,
@@ -36,6 +39,8 @@ pub enum Expr {
     Division(Box<Expr>, Box<Expr>),
     Equals(Box<Expr>, Box<Expr>),
     TypeCheckEquals(Box<Expr>, Box<Expr>),
+    NotEquals(Box<Expr>, Box<Expr>),
+    TypeNotEquals(Box<Expr>, Box<Expr>),
     If(Box<Expr>, Vec<Stmt>),
 }
 


### PR DESCRIPTION
Added support for the `!=` and `!==` expression operators in the interpreter and
parser to handle the inequality comparison between two values of different types
and added lexing support for the `!=` token.