### PR TITLE
✨ Refactor Parser to handle If expressions and scopes

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -156,8 +156,20 @@ impl<'a> Lexer<'a> {
             "true" => Some(Token::Boolean(true)),
             "false" => Some(Token::Boolean(false)),
             "if" => Some(Token::If),
-            "else" => Some(Token::Else),
-            "elseif" => Some(Token::ElseIf),
+            "else" => {
+                self.pos += 1;
+
+                let next_token = self.next_token();
+
+                match next_token {
+                    Some(Token::If) => Some(Token::ElseIf),
+                    Some(Token::BraceOpen) => {
+                        self.pos -= 1;
+                        Some(Token::Else)
+                    },
+                    _ => panic!("Unexpected token")
+                }
+            },
             _ => Some(Token::Identifier(ident.to_string())),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,35 +9,19 @@ use lexer::Lexer;
 
 fn main() {
     let code = r#"
-        let x = 3;
-        // let y = x + 3 + 3;
-        // let m = 'Manoj';
-        // log(x + 1);
-        // log(m);
-        // log(y - x);
-        // log(y * x);
-        // y = 10;
-        // let isWorking = 'true' == false;
-        // log(true == 1);
-        // log(true === 1)
+        let x = 6;
 
-        log(x != 2);
+        if (x == 3) {
+            log(x);
+        }
 
         if (x == 4) {
+            log('x is 4');
+        } else if (x == 6) {
+            log('x is 6');
+        } else {
             log('x is 3');
         }
-        // } else {
-        //     log('x is not 3');
-        // }
-
-        // {
-        //     let x = 5;
-        //     log(x);
-        // }
-
-        // reactive {
-        //     log(x);
-        // }
     "#;
     let mut lexer = Lexer::new(code);
     let mut tokens = Vec::new();
@@ -48,8 +32,11 @@ fn main() {
         tokens.push(token);
     }
 
+    let mut i = 0;
+
     for token in &tokens {
-        println!("{:?}", token);
+        println!("{:?}, {:?} token", token, i);
+        i += 1;
     }
 
     println!("\nLexer completed... \n");

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -21,8 +21,8 @@ pub enum Token {
     ParenClose,
     Comment(String),
     If,
-    Else,
     ElseIf,
+    Else,
     Log,
     Let,
 }
@@ -41,14 +41,16 @@ pub enum Expr {
     TypeCheckEquals(Box<Expr>, Box<Expr>),
     NotEquals(Box<Expr>, Box<Expr>),
     TypeNotEquals(Box<Expr>, Box<Expr>),
-    If(Box<Expr>, Vec<Stmt>),
+    If(Box<Expr>, Vec<Stmt>, Box<Stmt>),
+    // ControlFlow(Box<Expr>, Vec<Stmt>, Vec<Stmt>),
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Stmt {
     Let(String, Expr),
     Assignment(String, Expr),
-    If(Box<Expr>, Vec<Stmt>),
+    If(Box<Expr>, Vec<Stmt>, Box<Stmt>),
+    // ControlFlow(Box<Expr>, Vec<Stmt>, Vec<Stmt>),
     Log(Expr),
     Comment(String),
 }


### PR DESCRIPTION
Added functionality to properly parse If expressions and scopes in the Parser
module. Refactored the code to handle If conditions, If statements, Else if
statements, and Else statements within the scope. Updated the logic for
assignment parsing to provide a more specific error message when an equals
sign is expected after an identifier.

This commit improves the handling of If expressions and scopes in the parser
module.