### PR TITLE
✨ Refactor variable names in parser and interpreter modules

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -72,22 +72,21 @@ impl Interpreter {
                 let left = self.eval_expr(*left);
                 let right = self.eval_expr(*right);
 
-                match (left) {
+                match left {
                     Value::Float(left) => {
-                        let corced_right = match (right) {
+                        let corced_right = match right {
                             Value::Float(right) => Some(right),
                             Value::StringLiteral(right) => right.parse::<f64>().ok(),
                             Value::Boolean(right) => Some(right as i32 as f64),
-                            _ => Some(0.0),
                         };
 
-                        match (corced_right) {
+                        match corced_right {
                             Some(right) => Value::Boolean(left == right),
                             None => Value::Boolean(false),
                         }
                     },
                     Value::StringLiteral(left) => {
-                        let corced_right = match (right) {
+                        let corced_right = match right {
                             Value::Float(right) => Some(right.to_string()),
                             Value::StringLiteral(right) => Some(right),
                             Value::Boolean(right) => Some(right.to_string()),
@@ -96,7 +95,7 @@ impl Interpreter {
                         Value::Boolean(left == corced_right.unwrap())
                     }
                     Value::Boolean(left) => {
-                        let corced_right = match (right) {
+                        let corced_right = match right {
                             Value::Float(right) => Some(right as i32 != 0),
                             Value::StringLiteral(right) => {
                                 let value = right.parse::<i32>().ok();
@@ -110,9 +109,7 @@ impl Interpreter {
                         };
 
                         Value::Boolean(left == corced_right.unwrap())
-                    },
-                    _ => panic!("Expected two expressions to compare"),
-                
+                    }
                 }
             }
             Expr::TypeCheckEquals(left, right) => {
@@ -132,11 +129,10 @@ impl Interpreter {
 
                 match left {
                     Value::Float(left) => {
-                        let corced_right = match (right) {
+                        let corced_right = match right {
                             Value::Float(right) => Some(right),
                             Value::StringLiteral(right) => right.parse::<f64>().ok(),
                             Value::Boolean(right) => Some(right as i32 as f64),
-                            _ => Some(0.0),
                         };
 
                         match corced_right {
@@ -168,9 +164,7 @@ impl Interpreter {
                         };
 
                         Value::Boolean(left != corced_right.unwrap())
-                    },
-                    _ => panic!("Expected two expressions to compare"),
-                
+                    }
                 }
             }
             Expr::TypeNotEquals(left, right) => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -28,7 +28,7 @@ impl Parser {
     }
 
     fn parse_assignment (&mut self) -> Expr {
-        let token = self.tokens.get(self.pos);
+        let _token = self.tokens.get(self.pos);
         match self.next_token() {
             Some(Token::Assign) => self.parse_expr(),
             _ => panic!("Expected equals after identifier in assignment"),
@@ -52,7 +52,8 @@ impl Parser {
     fn parse_expr(&mut self) -> Expr {
         let mut expr = Vec::new();
 
-        while let token = self.next_token() {
+        loop {
+            let token = self.next_token();
             if token == Some(Token::Semicolon) || token == Some(Token::ParenClose) {
                 break;
             }
@@ -146,7 +147,7 @@ impl Parser {
                 // skip closing parenthesis
                 self.pos += 1;
 
-                let token = self.tokens.get(self.pos);
+                let _token = self.tokens.get(self.pos);
 
                 match self.next_token() {
                     Some(Token::BraceOpen) => {
@@ -165,7 +166,7 @@ impl Parser {
 
                                 let else_ast = self.parse_scope();
 
-                                let token = self.tokens.get(self.pos);
+                                let _token = self.tokens.get(self.pos);
 
                                 Expr::If(
                                     Box::new(condition),


### PR DESCRIPTION
Refactor variable names in parser and interpreter modules to improve clarity
and consistency.