### PR TITLE
✨ Refactor control flow statements in parser and interpreter

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,7 +28,7 @@ impl Interpreter {
                 Stmt::Log(expr) => self.eval_log(expr),
                 Stmt::Assignment(name, value) => self.eval_let(name, value),
                 Stmt::Comment(_) => (),
-                Stmt::If(condition, stmts, else_stmt) => self.eval_if(condition, stmts, else_stmt),
+                Stmt::ControlFlow(condition, stmts, else_stmt) => self.eval_if(condition, stmts, else_stmt),
             }
         }
     }
@@ -52,7 +52,7 @@ impl Interpreter {
             },
             Value::Boolean(false) => {
                 match *else_stmt {
-                    Stmt::If(condition, stmts, nested_else_stmt) => {
+                    Stmt::ControlFlow(condition, stmts, nested_else_stmt) => {
                         self.eval_if(condition, stmts, nested_else_stmt);
                     },
                     _ => ()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -158,7 +158,7 @@ impl Parser {
                         match next_token {
                             Some(Token::ElseIf) => {
                                 let else_if_stmt = self.parse_if();
-                                Expr::If(Box::new(condition), if_ast, Box::new(else_if_stmt))
+                                Expr::ControlFlow(Box::new(condition), if_ast, Box::new(else_if_stmt))
                             }
                             Some(Token::Else) => {
                                 // 
@@ -168,11 +168,11 @@ impl Parser {
 
                                 let _token = self.tokens.get(self.pos);
 
-                                Expr::If(
+                                Expr::ControlFlow(
                                     Box::new(condition),
                                     if_ast,
                                     Box::new(
-                                        Stmt::If(
+                                        Stmt::ControlFlow(
                                             Box::new(
                                                 Expr::Boolean(true)
                                             ),
@@ -188,7 +188,7 @@ impl Parser {
                             }
                             _ => {
                                 self.pos -= 1;
-                                Expr::If(Box::new(condition), if_ast, Box::new(Stmt::Comment("No else".to_string())))
+                                Expr::ControlFlow(Box::new(condition), if_ast, Box::new(Stmt::Comment("No else".to_string())))
                             },
                         }
                     },
@@ -199,7 +199,7 @@ impl Parser {
         };
 
         match expr {
-            Expr::If(condition, stmts, else_stmt) => Stmt::If(condition, stmts, else_stmt),
+            Expr::ControlFlow(condition, stmts, else_stmt) => Stmt::ControlFlow(condition, stmts, else_stmt),
             _ => panic!("Expected if"),
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -41,16 +41,14 @@ pub enum Expr {
     TypeCheckEquals(Box<Expr>, Box<Expr>),
     NotEquals(Box<Expr>, Box<Expr>),
     TypeNotEquals(Box<Expr>, Box<Expr>),
-    If(Box<Expr>, Vec<Stmt>, Box<Stmt>),
-    // ControlFlow(Box<Expr>, Vec<Stmt>, Vec<Stmt>),
+    ControlFlow(Box<Expr>, Vec<Stmt>, Box<Stmt>),
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Stmt {
     Let(String, Expr),
     Assignment(String, Expr),
-    If(Box<Expr>, Vec<Stmt>, Box<Stmt>),
-    // ControlFlow(Box<Expr>, Vec<Stmt>, Vec<Stmt>),
+    ControlFlow(Box<Expr>, Vec<Stmt>, Box<Stmt>),
     Log(Expr),
     Comment(String),
 }


### PR DESCRIPTION
Rename `If` to `ControlFlow` for better clarity and consistency in code.
Update `Stmt` and `Expr` enums to reflect the change in naming convention.