### PR TITLE
🔍 Refactor interpreter to handle code blocks efficiently

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -32,9 +32,13 @@ impl<'a> Lexer<'a> {
                     return token;
                 }
                 '\'' => {
-                    let token = self.read_string_literal();
+                    let token = self.read_string_literal('\'');
                     return token;
                 }
+                '"' => {
+                    let token = self.read_string_literal('\"');
+                    return token;
+                },
                 '!' => {
                     let char = self.code.chars().nth(self.pos + 1)?;
 
@@ -190,7 +194,7 @@ impl<'a> Lexer<'a> {
         Some(Token::Float(num.parse().unwrap()))
     }
 
-    fn read_string_literal(&mut self) -> Option<Token> {
+    fn read_string_literal(&mut self, delimiter: char) -> Option<Token> {
         let start: usize = self.pos;
 
         // Skip the opening quote
@@ -199,7 +203,7 @@ impl<'a> Lexer<'a> {
         while self.pos < self.code.len() {
             let c = self.code.chars().nth(self.pos)?;
 
-            if c == '\'' {
+            if c == delimiter {
                 break;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,27 +2,35 @@ mod parser;
 mod types;
 mod interpreter;
 mod lexer;
+mod scope;
 
 use parser::Parser;
 use interpreter::Interpreter;
 use lexer::Lexer;
+use scope::Scope;
 
 fn main() {
     let code = r#"
         let x = 6;
 
-        // if (x == 3) {
-        //     log(x);
-        // }
+        {
+            let y = 8;
+            let x = 1;
+            log(x); => 1
 
-        if (x == 4) {
-            log('x is 4');
-        } else if (x == 6) {
-            log('x is 6');
-        } else {
-            log('x is 3');
+            if (x == 1) {
+                let y = 2;
+                z = 3;
+                log(x); => 3
+                log(y); => 2
+            }
+
+            log(x); => 3
+            log(y); => 8
         }
+
     "#;
+
     let mut lexer = Lexer::new(code);
     let mut tokens = Vec::new();
 
@@ -57,7 +65,9 @@ fn main() {
 
     println!("Execution started... \n");
 
-    let mut interpreter = Interpreter::new();
+    let scope = Scope::new(None);
+
+    let mut interpreter = Interpreter::new(Some(scope));
     interpreter.eval(ast);
 
     println!("\nExecution completed... \n");

--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -1,0 +1,83 @@
+use std::{collections::HashMap, rc::Rc};
+use std::cell::RefCell;
+use crate::types::Value;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Scope {
+    parent: Option<Rc<RefCell<Scope>>>,
+    variables: RefCell<HashMap<String, Value>>,
+}
+
+impl Scope {
+    pub fn new(parent: Option<Scope>) -> Self {
+        match parent {
+            Some(parent) => Scope {
+                parent: Some(Rc::new(RefCell::new(parent))),
+                variables: RefCell::new(HashMap::new()),
+            },
+            None => Scope {
+                parent: None,
+                variables: RefCell::new(HashMap::new()),
+            }
+        }
+    }
+
+    pub fn with_rc(parent: Option<Rc<RefCell<Scope>>>) -> Self {
+        match parent {
+            Some(parent) => Scope {
+                parent: Some(parent),
+                variables: RefCell::new(HashMap::new()),
+            },
+            None => Scope {
+                parent: None,
+                variables: RefCell::new(HashMap::new()),
+            }
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<Value> {
+        let variables = self.variables.borrow();
+        if variables.contains_key(name) {
+            match variables.get(name) {
+                Some(value) => return Some(value.clone()),
+                None => (),
+            }
+        }
+
+        match &self.parent {
+            Some(parent) => parent.borrow().get(name),
+            None => None,
+        }
+    }
+
+    pub fn contains_key_local(&self, name: &str) -> bool {
+        self.variables.borrow().contains_key(name)
+    }
+
+    pub fn contains_key(&self, name: &str) -> bool {
+        if self.variables.borrow().contains_key(name) {
+            return true
+        }
+
+        match &self.parent {
+            Some(parent) => parent.borrow().contains_key(name),
+            None => false,
+        }
+    }
+
+    pub fn assign (&mut self, name: String, value: Value) {
+        if self.variables.borrow().contains_key(&name) {
+            self.variables.borrow_mut().insert(name, value);
+            return
+        }
+
+        match &mut self.parent {
+            Some(parent) => parent.borrow_mut().assign(name, value),
+            None => panic!("Variable not found: {}", name)
+        }
+    }
+
+    pub fn define(&mut self, name: String, value: Value) {
+        self.variables.borrow_mut().insert(name, value);
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -41,14 +41,22 @@ pub enum Expr {
     TypeCheckEquals(Box<Expr>, Box<Expr>),
     NotEquals(Box<Expr>, Box<Expr>),
     TypeNotEquals(Box<Expr>, Box<Expr>),
-    ControlFlow(Box<Expr>, Vec<Stmt>, Box<Stmt>),
+    ControlFlow(Box<Expr>, Box<Stmt>, Box<Stmt>),
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Stmt {
     Let(String, Expr),
     Assignment(String, Expr),
-    ControlFlow(Box<Expr>, Vec<Stmt>, Box<Stmt>),
+    ControlFlow(Box<Expr>, Box<Stmt>, Box<Stmt>),
+    CodeBlock(Vec<Stmt>),
     None,
     Log(Expr)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Value {
+    Float(f64),
+    StringLiteral(String),
+    Boolean(bool),
 }


### PR DESCRIPTION
- Update `Interpreter` struct to include an optional `Scope` field
- Modify `new` method to accept and initialize `Scope` if provided
- Implement `eval_code_block` method to handle code blocks
- Create new `Interpreter` instance for each code block evaluation by passing
  a cloned `Scope` instance.