### PR TITLE
✨ Refactor contains_key method in Scope class

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,4 +1,4 @@
-use crate::types::{Token};
+use crate::types::Token;
 
 #[derive(Debug, PartialEq)]
 

--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -54,17 +54,6 @@ impl Scope {
         self.variables.borrow().contains_key(name)
     }
 
-    pub fn contains_key(&self, name: &str) -> bool {
-        if self.variables.borrow().contains_key(name) {
-            return true
-        }
-
-        match &self.parent {
-            Some(parent) => parent.borrow().contains_key(name),
-            None => false,
-        }
-    }
-
     pub fn assign (&mut self, name: String, value: Value) {
         if self.variables.borrow().contains_key(&name) {
             self.variables.borrow_mut().insert(name, value);


### PR DESCRIPTION
Remove redundant contains_key method in Scope class and simplify code.