### PR TITLE
✨ Refactor: Add assignment evaluation to interpreter (#7)

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -42,6 +42,10 @@ impl Interpreter {
                         },
                     }
                 },
+                Stmt::ForLoop(_, _, _, _) => (),
+                Stmt::Expression(expr) => {
+                    return_value = self.eval_expr(*expr);
+                },
                 Stmt::None => (),
             }
         }
@@ -457,7 +461,6 @@ impl Interpreter {
             },
             Expr::FunctionCall(args, value) => self.eval_function_call(args, value),
             _ => {
-                println!("{:?}", expr);
                 panic!("Expected an expression")
             },
         }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -138,12 +138,32 @@ impl<'a> Lexer<'a> {
                     }
                 },
                 '+' => {
-                    self.pos += 1;
-                    return Some(Token::Addition);
+                    let char = self.code.chars().nth(self.pos + 1)?;
+
+                    match char {
+                        '+' => {
+                            self.pos += 2;
+                            return Some(Token::Increment)
+                        },
+                        _ => {
+                            self.pos += 1;
+                            return Some(Token::Addition)
+                        }
+                    }
                 }
                 '-' => {
-                    self.pos += 1;
-                    return Some(Token::Subtraction);
+                    let char = self.code.chars().nth(self.pos + 1)?;
+
+                    match char {
+                        '-' => {
+                            self.pos += 2;
+                            return Some(Token::Decrement)
+                        },
+                        _ => {
+                            self.pos += 1;
+                            return Some(Token::Subtraction)
+                        }
+                    }
                 }
                 '*' => {
                     self.pos += 1;
@@ -220,6 +240,7 @@ impl<'a> Lexer<'a> {
             "true" => Some(Token::Boolean(true)),
             "false" => Some(Token::Boolean(false)),
             "if" => Some(Token::If),
+            "for" => Some(Token::ForLoop),
             "else" => {
                 self.pos += 1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,4 +22,112 @@ mod tests {
 
         assert_eq!(output, types::Value::Float(10.0));
     }
+
+    #[test]
+    fn addition() {
+        let code = r#"
+            let a = 10;
+            let b = 20;
+            return a + b;
+        "#;
+
+        let mut runtime = Runtime::new(code);
+        let output = runtime.execute();
+
+        assert_eq!(output, types::Value::Float(30.0));
+    }
+
+    #[test]
+    fn increment () {
+        let code = r#"
+            let a = 0;
+            a++;
+            return a;
+        "#;
+
+        let mut runtime = Runtime::new(code);
+        let output = runtime.execute();
+
+        assert_eq!(output, types::Value::Float(1.0));
+    }
+
+    #[test]
+    fn decrement () {
+        let code = r#"
+            let a = 1;
+            a--;
+            return a;
+        "#;
+
+        let mut runtime = Runtime::new(code);
+        let output = runtime.execute();
+
+        assert_eq!(output, types::Value::Float(0.0));
+    }
+
+    #[test]
+    fn function_call () {
+        let code: &str = r#"
+            function add (a, b) {
+                return a + b;
+            }
+
+            return add(10, 20);
+        "#;
+
+        let mut runtime = Runtime::new(code);
+        let output = runtime.execute();
+
+        assert_eq!(output, types::Value::Float(30.0));
+    }
+
+    #[test]
+    fn function_call_stmt () {
+        let code: &str = r#"
+            function log_some (a) {
+                return a;
+            }
+
+            1 + 1;
+
+            return log_some(30);
+        "#;
+
+        let mut runtime = Runtime::new(code);
+        let output = runtime.execute();
+
+        assert_eq!(output, types::Value::Float(30.0));
+    }
+
+    #[test]
+    fn nested_function_call () {
+        let code: &str = r#"
+            function add (a, b) {
+                return a + b;
+            }
+
+            function main (x, y) {
+                return add(x, y);
+            }
+
+            return main(10, 20);
+        "#;
+
+        let mut runtime = Runtime::new(code);
+        let output = runtime.execute();
+    }
+
+    // #[test]
+    // fn for_loop () {
+    //     let code = r#"
+    //         for (let i = 0; i < 10; i++) {
+    //             log(i);
+    //         }
+    //     "#;
+
+    //     let mut runtime = Runtime::new(code);
+    //     let output = runtime.execute();
+
+    //     assert_eq!(output, types::Value::Float(10.0));
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,9 @@ use runtime::Runtime;
 fn main() {
     let code = r#"
         let a = 10;
-        let b = 20;
-        
-        function add(a, b) {
-            return a + b;
-        }
-
-        return add(a, b);
+        return
     "#;
+
 
     let mut runtime = Runtime::new(code);
     runtime.execute();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -30,6 +30,8 @@ pub enum Token {
     Subtraction,
     Multiplication,
     Division,
+    Increment,
+    Decrement,
 
     // punctuation
     Semicolon,
@@ -48,6 +50,8 @@ pub enum Token {
     Let,
     Function,
     Return,
+    ForLoop,
+    FunctionCall(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -72,7 +76,8 @@ pub enum Expr {
     FunctionCall(String, Vec<Expr>),
     LogicalAnd(Box<Expr>, Box<Expr>),
     LogicalOr(Box<Expr>, Box<Expr>),
-    LogicalNot(Box<Expr>)
+    LogicalNot(Box<Expr>),
+    Assignment(String, Box<Expr>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -85,6 +90,8 @@ pub enum Stmt {
     Function(String, Vec<String>, Box<Stmt>),
     Return(Box<Expr>),
     FunctionCall(String, Vec<Expr>),
+    ForLoop(Box<Stmt>, Box<Stmt>, Box<Stmt>, Box<Stmt>),
+    Expression(Box<Expr>),
     None,
 }
 


### PR DESCRIPTION
- Evaluate the expression of assignments in statements.
- Remove unnecessary debug print statement.
- Improve error handling for assignment expressions.