### PR TITLE
✨ Add REPL functionality and improve code execution

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -206,6 +206,7 @@ impl Interpreter {
 
             match signal {
                 Signal::Break => break,
+                Signal::Return => break,
                 _ => (),
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,4 +209,26 @@ mod tests {
 
         assert_eq!(output, types::Value::Float(55.0));
     }
+
+    #[test]
+
+    fn return_inside_loop () {
+        let code = r#"
+            let i = 0;
+
+            loop {
+                if (i >= 10) {
+                    break;
+                }
+                i++;
+            }
+
+            return i;
+        "#;
+
+        let mut runtime = Runtime::new(code);
+        let output = runtime.execute();
+
+        assert_eq!(output, types::Value::Float(10.0));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,18 +8,19 @@ mod types;
 use runtime::Runtime;
 
 fn main() {
-    let code = r#"
-        function fib (n) {
-            if (n <= 1) {
-                return n;
-            }
+    // let code = r#"
+    //     function fib (n) {
+    //         if (n <= 1) {
+    //             return n;
+    //         }
 
-            return fib(n - 1);
-        }
+    //         return fib(n - 1);
+    //     }
 
-        log(fib(100))
-    "#;
+    //     log(fib(100))
+    // "#;
 
-    let mut runtime = Runtime::new(code);
-    runtime.execute();
+    let mut runtime = Runtime::new("");
+    runtime.repl();
+    // runtime.execute();
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,6 +1,7 @@
+use std::io::{self, Write};
 use crate::scope::Scope;
 use crate::parser::Parser;
-use crate::interpreter::Interpreter;
+use crate::interpreter::{self, Interpreter};
 use crate::lexer::Lexer;
 use crate::types::{Token, Stmt, Value};
 
@@ -8,7 +9,6 @@ pub struct Runtime<'a> {
     tokens: Vec<Token>,
     ast: Vec<Stmt>,
     output: Value,
-    scope: Scope,
     code: &'a str
 }
 
@@ -18,13 +18,35 @@ impl<'a> Runtime<'a> {
             tokens: Vec::new(),
             ast: Vec::new(),
             output: Value::None,
-            scope: Scope::new(None),
             code
         }
     }
 
-    pub fn execute (&mut self) -> Value {
-        let mut lexer = Lexer::new(&self.code);
+    pub fn repl (&mut self) {
+        let scope = Scope::new(None);
+
+        loop {
+            print!("> ");
+            io::stdout().flush().unwrap();
+
+            let mut input = String::new();
+            io::stdin().read_line(&mut input).unwrap();
+
+            if input.trim() == "exit" {
+                break;
+            }
+
+            let ast = self.parse_ast(input);
+
+            let mut interpreter = Interpreter::new(Some(scope.clone()));
+            let (value, signal) = interpreter.eval(ast);
+
+            println!("{:?}", value);
+        }
+    }
+
+    pub fn parse_ast (&mut self, code: String) -> Vec<Stmt> {
+        let mut lexer = Lexer::new(&code);
         println!("Lexer started... \n");
 
         while let Some(token) = lexer.next_token() {
@@ -56,8 +78,13 @@ impl<'a> Runtime<'a> {
 
         println!("\nParsing completed... \n");
 
+        return local_ast;
+    }
+
+    pub fn execute (&mut self) -> Value {
         println!("Execution started... \n");
 
+        let local_ast = self.parse_ast(self.code.to_string());
         let scope = Scope::new(None);
 
         let mut interpreter = Interpreter::new(Some(scope));


### PR DESCRIPTION
Simplify the main function and introduce a REPL to interact with the
runtime. Update the `execute` method to parse AST before execution and
return executed value. Remove unnecessary scope field from Runtime
struct to avoid confusion.